### PR TITLE
Add GitHub Copilot as a model provider

### DIFF
--- a/core/commands/slash/githubCopilot.ts
+++ b/core/commands/slash/githubCopilot.ts
@@ -1,0 +1,56 @@
+import { SlashCommand } from "../../index";
+
+const GitHubCopilotCommand: SlashCommand = {
+  name: "github-copilot",
+  description: "Interact with GitHub Copilot",
+  run: async function* ({ input, llm, history, ide }) {
+    // Remove slash command prefix from input
+    let userInput = input;
+    if (userInput.startsWith(`/github-copilot`)) {
+      userInput = userInput.slice("github-copilot".length + 1).trimStart();
+    }
+
+    // Render prompt template
+    const promptUserInput = userInput;
+
+    const messages = [...history];
+    // Find the last chat message with this slash command and replace it with the user input
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      const { role, content } = message;
+      if (role !== "user") {
+        continue;
+      }
+
+      if (
+        Array.isArray(content) &&
+        content.some((part) => part.text?.startsWith(`/github-copilot`))
+      ) {
+        messages[i] = {
+          ...message,
+          content: content.map((part) => {
+            return part.text?.startsWith(`/github-copilot`)
+              ? { ...part, text: promptUserInput }
+              : part;
+          }),
+        };
+        break;
+      } else if (
+        typeof content === "string" &&
+        content.startsWith(`/github-copilot`)
+      ) {
+        messages[i] = { ...message, content: promptUserInput };
+        break;
+      }
+    }
+
+    for await (const chunk of llm.streamChat(
+      messages,
+      new AbortController().signal,
+    )) {
+      yield chunk;
+    }
+  },
+};
+
+export default GitHubCopilotCommand;

--- a/core/commands/slash/index.ts
+++ b/core/commands/slash/index.ts
@@ -5,6 +5,7 @@ import HttpSlashCommand from "./http";
 import OnboardSlashCommand from "./onboard";
 import ReviewMessageCommand from "./review";
 import ShareSlashCommand from "./share";
+import GitHubCopilotCommand from "./githubCopilot";
 
 export default [
   DraftIssueCommand,
@@ -14,4 +15,5 @@ export default [
   CommitMessageCommand,
   ReviewMessageCommand,
   OnboardSlashCommand,
+  GitHubCopilotCommand,
 ];

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -19,6 +19,20 @@ export const DEFAULT_AUTOCOMPLETE_MODEL_CONFIG: ModelDescription = {
   apiKey: "",
 };
 
+export const GITHUB_COPILOT_CHAT_MODEL_CONFIG: ModelDescription = {
+  model: "github-copilot",
+  provider: "github-copilot",
+  apiKey: "",
+  title: "GitHub Copilot",
+};
+
+export const GITHUB_COPILOT_AUTOCOMPLETE_MODEL_CONFIG: ModelDescription = {
+  title: "GitHub Copilot",
+  provider: "github-copilot",
+  model: "github-copilot",
+  apiKey: "",
+};
+
 export const FREE_TRIAL_MODELS: ModelDescription[] = [
   {
     title: "Claude 3.5 Sonnet (Free Trial)",
@@ -93,15 +107,15 @@ export const defaultSlashCommandsJetBrains = [
 ];
 
 export const defaultConfig: SerializedContinueConfig = {
-  models: [DEFAULT_CHAT_MODEL_CONFIG],
-  tabAutocompleteModel: DEFAULT_AUTOCOMPLETE_MODEL_CONFIG,
+  models: [DEFAULT_CHAT_MODEL_CONFIG, GITHUB_COPILOT_CHAT_MODEL_CONFIG],
+  tabAutocompleteModel: [DEFAULT_AUTOCOMPLETE_MODEL_CONFIG, GITHUB_COPILOT_AUTOCOMPLETE_MODEL_CONFIG],
   contextProviders: defaultContextProvidersVsCode,
   slashCommands: defaultSlashCommandsVscode,
 };
 
 export const defaultConfigJetBrains: SerializedContinueConfig = {
-  models: [DEFAULT_CHAT_MODEL_CONFIG],
-  tabAutocompleteModel: DEFAULT_AUTOCOMPLETE_MODEL_CONFIG,
+  models: [DEFAULT_CHAT_MODEL_CONFIG, GITHUB_COPILOT_CHAT_MODEL_CONFIG],
+  tabAutocompleteModel: [DEFAULT_AUTOCOMPLETE_MODEL_CONFIG, GITHUB_COPILOT_AUTOCOMPLETE_MODEL_CONFIG],
   contextProviders: defaultContextProvidersJetBrains,
   slashCommands: defaultSlashCommandsJetBrains,
 };

--- a/core/llm/llms/GitHubCopilot.test.ts
+++ b/core/llm/llms/GitHubCopilot.test.ts
@@ -1,0 +1,172 @@
+import { jest } from "@jest/globals";
+import GitHubCopilot from "./GitHubCopilot";
+import { CompletionRequest, CompletionResponse } from "../index";
+
+describe("GitHubCopilot", () => {
+  let copilot: GitHubCopilot;
+
+  beforeEach(() => {
+    copilot = new GitHubCopilot({
+      apiKey: "test-api-key",
+    });
+  });
+
+  test("should have providerName as 'github-copilot'", () => {
+    expect(GitHubCopilot.providerName).toBe("github-copilot");
+  });
+
+  test("should stream completion from GitHub Copilot API", async () => {
+    const mockResponse = {
+      choices: [
+        {
+          text: "This is a test completion.",
+        },
+      ],
+    };
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => {
+            let done = false;
+            return {
+              read: () =>
+                Promise.resolve({
+                  value: new TextEncoder().encode(JSON.stringify(mockResponse)),
+                  done,
+                }),
+            };
+          },
+        },
+      }),
+    ) as jest.Mock;
+
+    const request: CompletionRequest = {
+      prompt: "Test prompt",
+      max_tokens: 10,
+    };
+
+    const responses: CompletionResponse[] = [];
+    for await (const response of copilot._streamComplete(request)) {
+      responses.push(response);
+    }
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0].choices[0].text).toBe("This is a test completion.");
+  });
+
+  test("should throw error if GitHub Copilot API response is not ok", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        statusText: "Bad Request",
+      }),
+    ) as jest.Mock;
+
+    const request: CompletionRequest = {
+      prompt: "Test prompt",
+      max_tokens: 10,
+    };
+
+    await expect(async () => {
+      for await (const _ of copilot._streamComplete(request)) {
+        // do nothing
+      }
+    }).rejects.toThrow("GitHub Copilot API error: Bad Request");
+  });
+
+  test("should throw error if no response body from GitHub Copilot API", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: null,
+      }),
+    ) as jest.Mock;
+
+    const request: CompletionRequest = {
+      prompt: "Test prompt",
+      max_tokens: 10,
+    };
+
+    await expect(async () => {
+      for await (const _ of copilot._streamComplete(request)) {
+        // do nothing
+      }
+    }).rejects.toThrow("No response body from GitHub Copilot API");
+  });
+
+  test("should stream chat from GitHub Copilot API", async () => {
+    const mockResponse = {
+      choices: [
+        {
+          delta: {
+            content: "This is a test chat response.",
+          },
+        },
+      ],
+    };
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => {
+            let done = false;
+            return {
+              read: () =>
+                Promise.resolve({
+                  value: new TextEncoder().encode(JSON.stringify(mockResponse)),
+                  done,
+                }),
+            };
+          },
+        },
+      }),
+    ) as jest.Mock;
+
+    const messages = [{ role: "user", content: "Test message" }];
+
+    const responses: any[] = [];
+    for await (const response of copilot._streamChat(messages, new AbortController().signal, {})) {
+      responses.push(response);
+    }
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0].content).toBe("This is a test chat response.");
+  });
+
+  test("should throw error if GitHub Copilot API response is not ok for chat", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        statusText: "Bad Request",
+      }),
+    ) as jest.Mock;
+
+    const messages = [{ role: "user", content: "Test message" }];
+
+    await expect(async () => {
+      for await (const _ of copilot._streamChat(messages, new AbortController().signal, {})) {
+        // do nothing
+      }
+    }).rejects.toThrow("GitHub Copilot API error: Bad Request");
+  });
+
+  test("should throw error if no response body from GitHub Copilot API for chat", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: null,
+      }),
+    ) as jest.Mock;
+
+    const messages = [{ role: "user", content: "Test message" }];
+
+    await expect(async () => {
+      for await (const _ of copilot._streamChat(messages, new AbortController().signal, {})) {
+        // do nothing
+      }
+    }).rejects.toThrow("No response body from GitHub Copilot API");
+  });
+});

--- a/core/llm/llms/GitHubCopilot.ts
+++ b/core/llm/llms/GitHubCopilot.ts
@@ -1,0 +1,54 @@
+import { ChatMessage, CompletionOptions, LLMOptions } from "../../index.js";
+import { renderChatMessage } from "../../util/messageContent.js";
+import { BaseLLM } from "../index.js";
+import { streamSse } from "../stream.js";
+
+class GitHubCopilot extends BaseLLM {
+  static providerName = "github-copilot";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.githubcopilot.com/v1/",
+  };
+
+  protected async *_streamComplete(
+    prompt: string,
+    signal: AbortSignal,
+    options: CompletionOptions,
+  ): AsyncGenerator<string> {
+    const messages = [{ role: "user" as const, content: prompt }];
+    for await (const update of this._streamChat(messages, signal, options)) {
+      yield renderChatMessage(update);
+    }
+  }
+
+  protected async *_streamChat(
+    messages: ChatMessage[],
+    signal: AbortSignal,
+    options: CompletionOptions,
+  ): AsyncGenerator<ChatMessage> {
+    const response = await this.fetch(new URL("chat/completions", this.apiBase), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        messages,
+        stream: true,
+        model: this.model,
+        ...options,
+      }),
+      signal,
+    });
+
+    for await (const value of streamSse(response)) {
+      if (value.choices?.[0]?.delta?.content) {
+        yield {
+          role: "assistant",
+          content: value.choices[0].delta.content,
+        };
+      }
+    }
+  }
+}
+
+export default GitHubCopilot;

--- a/docs/docs/customize/model-providers/top-level/github-copilot.md
+++ b/docs/docs/customize/model-providers/top-level/github-copilot.md
@@ -1,0 +1,54 @@
+---
+title: GitHub Copilot
+slug: ../github-copilot
+---
+
+:::info
+
+You can get an API key from the [GitHub Copilot settings](https://github.com/settings/copilot).
+
+:::
+
+## Chat model
+
+We recommend configuring **GitHub Copilot** as your chat model.
+
+```json title="config.json"
+{
+  "models": [
+    {
+      "title": "GitHub Copilot",
+      "provider": "github-copilot",
+      "model": "github-copilot",
+      "apiKey": "[API_KEY]"
+    }
+  ]
+}
+```
+
+## Autocomplete model
+
+We recommend configuring **GitHub Copilot** as your autocomplete model.
+
+```json title="config.json"
+{
+  "tabAutocompleteModel": {
+    "title": "GitHub Copilot",
+    "provider": "github-copilot",
+    "model": "github-copilot",
+    "apiKey": "[API_KEY]"
+  }
+}
+```
+
+## Embeddings model
+
+GitHub Copilot currently does not offer any embeddings models.
+
+[Click here](../../model-types/embeddings.md) to see a list of embeddings model providers.
+
+## Reranking model
+
+GitHub Copilot currently does not offer any reranking models.
+
+[Click here](../../model-types/reranking.md) to see a list of reranking model providers.


### PR DESCRIPTION
Add support for GitHub Copilot as a model provider in Continue.

* **Core Implementation**
  - Add `GitHubCopilot.ts` to `core/llm/llms` to implement the GitHub Copilot model provider.
  - Implement `_streamComplete` and `_streamChat` methods for GitHub Copilot API.

* **Configuration**
  - Update `core/config/default.ts` to include GitHub Copilot in the default model configurations.

* **Documentation**
  - Add `github-copilot.md` to `docs/docs/customize/model-providers/top-level` to document how to configure GitHub Copilot as a model provider.

* **Slash Commands**
  - Add `githubCopilot.ts` to `core/commands/slash` to implement a slash command for GitHub Copilot.
  - Update `core/commands/slash/index.ts` to include the GitHub Copilot slash command.

* **Testing**
  - Add `GitHubCopilot.test.ts` to `core/llm/llms` to cover the GitHub Copilot model provider with tests.

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
